### PR TITLE
Add CVC5 GitHub Actions workflow

### DIFF
--- a/.github/workflows/cvc5.yml
+++ b/.github/workflows/cvc5.yml
@@ -1,0 +1,30 @@
+name: Build CVC5 and Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Install basic tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake git python3
+          
+      - name: Clone and build CVC5
+        run: |
+          git clone https://github.com/cvc5/cvc5.git cvc5-src
+          cd cvc5-src
+          ./configure.sh debug
+          make -j$(nproc)
+          
+      - name: Test binary
+        run: |
+          cd cvc5-src
+          ./build/bin/cvc5 --version
+          ./build/bin/cvc5 --help


### PR DESCRIPTION
- Manual workflow dispatch for building and testing CVC5
- Clones CVC5 repository and builds in debug mode
- Installs required dependencies (build-essential, cmake, git, python3)
- Tests the built binary with --version and --help flags
- Runs on Ubuntu latest runner