### PR TITLE
Fix CVC5 workflow: add auto-download and update actions

### DIFF
--- a/.github/workflows/cvc5.yml
+++ b/.github/workflows/cvc5.yml
@@ -9,7 +9,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Install basic tools
         run: |
@@ -18,13 +18,13 @@ jobs:
           
       - name: Clone and build CVC5
         run: |
-          git clone https://github.com/cvc5/cvc5.git cvc5-src
-          cd cvc5-src
-          ./configure.sh debug
+          git clone https://github.com/cvc5/cvc5.git cvc5
+          cd cvc5
+          ./configure.sh debug --auto-download
           make -j$(nproc)
           
       - name: Test binary
         run: |
-          cd cvc5-src
+          cd cvc5
           ./build/bin/cvc5 --version
           ./build/bin/cvc5 --help


### PR DESCRIPTION
- Add --auto-download flag to configure.sh to automatically download dependencies like CaDiCaL
- Update actions/checkout from v4 to v5 (latest version)
- Change directory name from cvc5-src to cvc5 for consistency
- Fix dependency resolution issues that were causing build failures