### PR TITLE
Fix CVC5 workflow: run make from build directory

### DIFF
--- a/.github/workflows/cvc5.yml
+++ b/.github/workflows/cvc5.yml
@@ -1,10 +1,10 @@
-name: Build CVC5 and Test
+name: CVC5
 
 on:
   workflow_dispatch:
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     
     steps:
@@ -21,6 +21,7 @@ jobs:
           git clone https://github.com/cvc5/cvc5.git cvc5
           cd cvc5
           ./configure.sh debug --auto-download
+          cd build
           make -j$(nproc)
           
       - name: Test binary


### PR DESCRIPTION
- Add 'cd build' before running make command
- Fixes 'No targets specified and no makefile found' error
- CVC5 configure.sh creates build directory with Makefile
- Build process now follows correct CVC5 build procedure