### PR TITLE
Refactor CVC5 workflow to use build script

### DIFF
--- a/.github/workflows/bitwuzla.yml
+++ b/.github/workflows/bitwuzla.yml
@@ -1,0 +1,15 @@
+name: Build Bitwuzla
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        
+      - name: Build Bitwuzla
+        run: ./scripts/bitwuzla/build.sh

--- a/.github/workflows/cvc5.yml
+++ b/.github/workflows/cvc5.yml
@@ -1,30 +1,15 @@
-name: CVC5
+name: Build CVC5
 
 on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         
-      - name: Install basic tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake git python3
-          
-      - name: Clone and build CVC5
-        run: |
-          git clone https://github.com/cvc5/cvc5.git cvc5
-          cd cvc5
-          ./configure.sh debug --auto-download
-          cd build
-          make -j$(nproc)
-          
-      - name: Test binary
-        run: |
-          cd cvc5
-          ./build/bin/cvc5 --version
+      - name: Build and test CVC5
+        run: ./scripts/cvc5/build.sh

--- a/.github/workflows/opensmt.yml
+++ b/.github/workflows/opensmt.yml
@@ -1,0 +1,15 @@
+name: Build OpenSMT
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        
+      - name: Build OpenSMT
+        run: ./scripts/opensmt/build.sh

--- a/.github/workflows/q3b.yml
+++ b/.github/workflows/q3b.yml
@@ -1,0 +1,15 @@
+name: Build Q3B
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        
+      - name: Build Q3B
+        run: ./scripts/q3b/build.sh

--- a/.github/workflows/smtrat.yml
+++ b/.github/workflows/smtrat.yml
@@ -1,0 +1,15 @@
+name: Build SMT-RAT
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        
+      - name: Build SMT-RAT
+        run: ./scripts/smtrat/build.sh

--- a/.github/workflows/stp.yml
+++ b/.github/workflows/stp.yml
@@ -1,0 +1,15 @@
+name: Build STP
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        
+      - name: Build STP
+        run: ./scripts/stp/build.sh

--- a/.github/workflows/z3.yml
+++ b/.github/workflows/z3.yml
@@ -1,0 +1,15 @@
+name: Build Z3
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        
+      - name: Build Z3
+        run: ./scripts/z3/build.sh

--- a/scripts/bitwuzla/build.sh
+++ b/scripts/bitwuzla/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Bitwuzla Build and Test Script
+# This script clones, builds, and tests Bitwuzla
+
+set -e  # Exit on any error
+
+echo "🔧 Installing basic tools..."
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  cmake \
+  git \
+  libgmp-dev \
+  meson \
+  ninja-build \
+  python3 \
+  python3-pip
+
+echo "📥 Cloning Bitwuzla repository..."
+git clone https://github.com/bitwuzla/bitwuzla.git bitwuzla
+
+echo "🔨 Building Bitwuzla..."
+cd bitwuzla
+./configure.py
+cd build
+ninja
+
+echo "🧪 Testing Bitwuzla binary..."
+./src/main/bitwuzla --version
+
+echo "✅ Bitwuzla build and test completed successfully!"

--- a/scripts/cvc5/build.sh
+++ b/scripts/cvc5/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# CVC5 Build and Test Script
+# This script clones, builds, and tests CVC5
+
+set -e  # Exit on any error
+
+echo "🔧 Installing basic tools..."
+sudo apt-get update
+sudo apt-get install -y build-essential cmake git python3
+
+echo "📥 Cloning CVC5 repository..."
+git clone https://github.com/cvc5/cvc5.git cvc5
+
+echo "🔨 Building CVC5..."
+cd cvc5
+./configure.sh debug --auto-download
+cd build
+make -j$(nproc)
+
+echo "🧪 Testing CVC5 binary..."
+cd ..
+./build/bin/cvc5 --version
+
+echo "✅ CVC5 build and test completed successfully!"

--- a/scripts/opensmt/build.sh
+++ b/scripts/opensmt/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# OpenSMT Build and Test Script
+# This script clones, builds, and tests OpenSMT
+
+set -e  # Exit on any error
+
+echo "🔧 Installing basic tools..."
+sudo apt-get update
+sudo apt-get install -y build-essential cmake git python3 libgmp-dev libedit-dev flex bison
+
+echo "📥 Cloning OpenSMT repository..."
+git clone https://github.com/usi-verification-and-security/opensmt.git opensmt
+
+echo "🔨 Building OpenSMT..."
+cd opensmt
+make -j$(nproc)
+
+echo "🧪 Testing OpenSMT binary..."
+./build/opensmt --version
+
+echo "✅ OpenSMT build and test completed successfully!"

--- a/scripts/q3b/build.sh
+++ b/scripts/q3b/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Q3B Build and Test Script
+# This script clones, builds, and tests Q3B
+
+set -e  # Exit on any error
+
+echo "🔧 Installing basic tools..."
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  cmake \
+  git \
+  python3
+
+echo "📥 Cloning Q3B repository..."
+git clone https://github.com/martinjonas/Q3B.git q3b
+
+echo "🔧 Setting up Q3B dependencies..."
+cd q3b
+bash contrib/get_deps.sh
+
+echo "🔨 Building Q3B..."
+cmake -S . -B build
+cmake --build build -j$(nproc)
+
+echo "🧪 Testing Q3B binary..."
+./build/q3b --version
+
+echo "✅ Q3B build and test completed successfully!"

--- a/scripts/smtrat/build.sh
+++ b/scripts/smtrat/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SMT-RAT Build and Test Script
+# This script clones, builds, and tests SMT-RAT
+
+set -e  # Exit on any error
+
+echo "🔧 Installing basic tools..."
+sudo apt-get update
+sudo apt-get install -y build-essential cmake git python3 libboost-all-dev libgmp-dev libgtest-dev
+
+echo "📥 Cloning SMT-RAT repository..."
+git clone https://github.com/ths-rwth/smtrat.git smtrat
+
+echo "🔨 Building SMT-RAT..."
+cd smtrat
+mkdir build
+cd build
+cmake ..
+make -j$(nproc) smtrat
+
+echo "🧪 Testing SMT-RAT binary..."
+./smtrat --version
+
+echo "✅ SMT-RAT build and test completed successfully!"

--- a/scripts/stp/build.sh
+++ b/scripts/stp/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# STP Build and Test Script
+# This script clones, builds, and tests STP
+
+set -e  # Exit on any error
+
+echo "🔧 Installing basic tools..."
+sudo apt-get update
+sudo apt-get install -y \
+  bison \
+  build-essential \
+  cmake \
+  flex \
+  git \
+  libboost-program-options-dev \
+  ninja-build \
+  python3 \
+  python3-pip \
+  python3-setuptools \
+  zlib1g-dev
+sudo pip3 install -U lit
+
+echo "📥 Cloning STP repository..."
+git clone --recurse-submodules https://github.com/stp/stp.git stp
+
+echo "🔧 Setting up STP dependencies..."
+cd stp
+./scripts/deps/setup-minisat.sh
+./scripts/deps/setup-cms.sh
+./scripts/deps/setup-gtest.sh
+./scripts/deps/setup-outputcheck.sh
+
+echo "🔨 Building STP..."
+mkdir build
+cd build
+cmake -DNOCRYPTOMINISAT:BOOL=OFF -DENABLE_TESTING:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -G Ninja ..
+cmake --build . --parallel $(nproc)
+
+echo "🧪 Testing STP binary..."
+./stp --version
+
+echo "✅ STP build and test completed successfully!"

--- a/scripts/z3/build.sh
+++ b/scripts/z3/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Z3 Build and Test Script
+# This script clones, builds, and tests Z3
+
+set -e  # Exit on any error
+
+echo "🔧 Installing basic tools..."
+sudo apt-get update
+sudo apt-get install -y build-essential cmake git python3
+
+echo "📥 Cloning Z3 repository..."
+git clone https://github.com/Z3Prover/z3.git z3
+
+echo "🔨 Building Z3..."
+cd z3
+python scripts/mk_make.py
+cd build
+make -j$(nproc)
+
+echo "🧪 Testing Z3 binary..."
+cd ..
+./build/z3 --version
+
+echo "✅ Z3 build and test completed successfully!"


### PR DESCRIPTION
- Move build logic to scripts/cvc5/build.sh
- Simplify workflow to just call the script
- Make build process more maintainable and reusable