### PR TITLE
Fix commit order validation: use committer date instead of author date

### DIFF
--- a/scripts/scheduling/manager.py
+++ b/scripts/scheduling/manager.py
@@ -124,7 +124,7 @@ def verify_commit_is_newer(repo_url: str, newer_commit: str, older_commit: str, 
             response.raise_for_status()
             data = response.json()
             
-            commit_date_str = data.get('commit', {}).get('author', {}).get('date')
+            commit_date_str = data.get('commit', {}).get('committer', {}).get('date')
             if commit_date_str:
                 commit_date = datetime.fromisoformat(commit_date_str.replace('Z', '+00:00'))
                 print(f" date={commit_date.isoformat()}")


### PR DESCRIPTION
## Summary
- `verify_commit_is_newer` was comparing **author dates**, but the GitHub commits API sorts by **committer date**
- A commit authored before `last_checked` but pushed/merged after it would fail the date check and abort the manager with exit code 1
- Fix: read `committer.date` instead of `author.date` (the ordering check in `verify_commit_is_newer`)

## Root cause
`99099255` in z3 was authored ~3h before `fbeb4b22` but pushed after it, causing the validation to incorrectly treat it as an older commit.

## Test plan
- [ ] Re-run the z3 manager workflow — validation should pass for commits with older author dates that were merged recently