### PR TITLE
Extract S3 upload into composite action, add test workflow

### DIFF
--- a/.github/actions/s3-put-object/action.yml
+++ b/.github/actions/s3-put-object/action.yml
@@ -1,0 +1,19 @@
+name: S3 put-object
+description: Uploads a file to the configured S3/R2 bucket via aws s3api put-object
+inputs:
+  key:
+    description: 'Destination object key within the bucket'
+    required: true
+  file:
+    description: 'Path to the local file to upload'
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        aws s3api put-object \
+          --bucket "$AWS_BUCKET_NAME" \
+          --key "${{ inputs.key }}" \
+          --body "${{ inputs.file }}"
+        echo "✅ Uploaded ${{ inputs.file }} to s3://$AWS_BUCKET_NAME/${{ inputs.key }}"

--- a/.github/workflows/cvc5-build.yml
+++ b/.github/workflows/cvc5-build.yml
@@ -142,14 +142,10 @@ jobs:
 
       - name: Upload production binary to S3
         if: steps.check-queue.outputs.should_upload == 'true'
-        run: |
-            aws s3api put-object \
-              --bucket $AWS_BUCKET_NAME \
-              --key solvers/cvc5/builds/v2/production/${{ steps.get-commit.outputs.commit_hash }}.tar.gz \
-              --body cvc5/build/artifacts.tar.gz \
-              --endpoint-url https://7c6df65a29da9bdb8253b0615157058c.r2.cloudflarestorage.com \
-              --region auto
-            echo "✅ Uploaded production binary to S3"
+        uses: ./.github/actions/s3-put-object
+        with:
+          key: solvers/cvc5/builds/v2/production/${{ steps.get-commit.outputs.commit_hash }}.tar.gz
+          file: cvc5/build/artifacts.tar.gz
       
       - name: Discard build (not in queue)
         if: steps.check-queue.outputs.should_upload == 'false'
@@ -256,14 +252,10 @@ jobs:
       
       - name: Upload coverage binary to S3
         if: steps.check-queue-coverage.outputs.should_upload == 'true'
-        run: |
-          aws s3api put-object \
-            --bucket $AWS_BUCKET_NAME \
-            --key solvers/cvc5/builds/v2/coverage/${{ steps.get-commit.outputs.commit_hash }}.tar.gz \
-            --body cvc5/build/artifacts.tar.gz \
-            --endpoint-url https://7c6df65a29da9bdb8253b0615157058c.r2.cloudflarestorage.com \
-            --region auto
-          echo "✅ Uploaded coverage binary to S3"
+        uses: ./.github/actions/s3-put-object
+        with:
+          key: solvers/cvc5/builds/v2/coverage/${{ steps.get-commit.outputs.commit_hash }}.tar.gz
+          file: cvc5/build/artifacts.tar.gz
       
       - name: Discard coverage build (not in queue)
         if: steps.check-queue-coverage.outputs.should_upload == 'false'

--- a/.github/workflows/test-s3-put-object.yml
+++ b/.github/workflows/test-s3-put-object.yml
@@ -1,0 +1,33 @@
+name: Test s3-put-object action
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure storage backend
+        uses: ./.github/actions/configure-storage
+        with:
+          secrets: ${{ toJSON(secrets) }}
+          storage_provider: ${{ vars.AWS_STORAGE_PROVIDER }}
+
+      - name: Create test file
+        run: echo "s3-put-object test $(date -u +%FT%TZ)" > test-object.txt
+
+      - name: Upload test file
+        uses: ./.github/actions/s3-put-object
+        with:
+          key: _ci-tests/s3-put-object/${{ github.run_id }}.txt
+          file: test-object.txt
+
+      - name: Verify object exists
+        run: aws s3api head-object --bucket "$AWS_BUCKET_NAME" --key "_ci-tests/s3-put-object/${{ github.run_id }}.txt"
+
+      - name: Clean up test object
+        if: always()
+        run: aws s3api delete-object --bucket "$AWS_BUCKET_NAME" --key "_ci-tests/s3-put-object/${{ github.run_id }}.txt"


### PR DESCRIPTION
Wraps the aws s3api put-object calls in cvc5-build.yml as a reusable composite action, and drops the hardcoded R2 endpoint/region hack in favor of the AWS_ENDPOINT_URL_S3/AWS_REGION env vars already exported by configure-storage. Adds a workflow_dispatch test to verify uploads work end-to-end.


Claude-Session: https://claude.ai/code/session_01ChMNZovnzksQU7bhjW1Jyj